### PR TITLE
Make Cassandra connections more robust

### DIFF
--- a/sql-to-nosql/nosql/docker-compose.yml
+++ b/sql-to-nosql/nosql/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       restart_policy:
         condition: on-failure
         delay: 5s
-        max_attempts: 3
+        max_attempts: 100
         window: 60s
 
 networks:

--- a/sql-to-nosql/nosql/main.go
+++ b/sql-to-nosql/nosql/main.go
@@ -17,6 +17,7 @@ func main() {
 	cluster := gocql.NewCluster("cassandra", "cassandra2", "cassandra3")
 	cluster.Keyspace = "app"
 	cluster.Consistency = gocql.Quorum
+	cluster.ConnectTimeout = time.Second * 10
 	cluster.Authenticator = gocql.PasswordAuthenticator{
 		Username: "cassandra",
 		Password: "cassandra",

--- a/sql-to-nosql/nosql/main.go
+++ b/sql-to-nosql/nosql/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	log.SetOutput(os.Stdout)
 
-	cluster := gocql.NewCluster("cassandra", "cassandra2", "cassandra3")
+	cluster := gocql.NewCluster("cassandra")
 	cluster.Keyspace = "app"
 	cluster.Consistency = gocql.Quorum
 	cluster.ConnectTimeout = time.Second * 10


### PR DESCRIPTION
Cassandra can be slow to start up and to receive a new connection, needs longer waits.